### PR TITLE
improve auth logic

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -23,7 +23,8 @@ module.exports.signup = async (req, res) => {
 
 module.exports.logout = async (req, res) => {
   try {
-    RefreshToken.send(req, "");
+    RefreshToken.clear(res);
+    res.json({ message: "successfully logged out" });
   } catch (err) {
     return res.status(422).send({ message: err.message });
   }
@@ -104,10 +105,10 @@ module.exports.refreshToken = async (req, res) => {
     }
 
     const data = generateTokens({ user });
-    let { refreshToken } = data;
+    let { accessToken } = data;
 
-    RefreshToken.send(res, refreshToken);
-    return res.send(data);
+    // RefreshToken.send(res, refreshToken);
+    return res.send({ accessToken });
   } catch (err) {
     console.error(err);
     return res.status(StatusCodes.UNAUTHORIZED).send(response);

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const {
   signup,
   signin,
+  logout,
   refreshToken,
   getOTPEmail,
   getOTPMobileNo,
@@ -22,6 +23,7 @@ const validate = require("../validations/validate");
 
 router.post("/sign-up", signUpValidationRules(), validate, signup);
 router.post("/sign-in", signInValidationRules(), validate, signin);
+router.post("/logout", logout);
 router.post("/refresh-token", refreshToken);
 router.post(
   "/get-otp/email",

--- a/src/services/auth/AccessToken/create.js
+++ b/src/services/auth/AccessToken/create.js
@@ -2,7 +2,8 @@ const { sign } = require("jsonwebtoken");
 
 const create = (payload) => {
   return sign(payload, process.env.ACCESS_TOKEN_SECRET, {
-    expiresIn: process.env.NODE_ENV === "production" ? 5 * 60 : "7d",
+    // expiresIn: process.env.NODE_ENV === "production" ? 5 * 60 : "7d",
+    expiresIn: "7d",
   });
 };
 

--- a/src/services/auth/AccessToken/create.js
+++ b/src/services/auth/AccessToken/create.js
@@ -2,7 +2,7 @@ const { sign } = require("jsonwebtoken");
 
 const create = (payload) => {
   return sign(payload, process.env.ACCESS_TOKEN_SECRET, {
-    expiresIn: 5 * 60,
+    expiresIn: process.env.NODE_ENV === "production" ? 5 * 60 : "7d",
   });
 };
 

--- a/src/services/auth/AccessToken/create.js
+++ b/src/services/auth/AccessToken/create.js
@@ -2,7 +2,7 @@ const { sign } = require("jsonwebtoken");
 
 const create = (payload) => {
   return sign(payload, process.env.ACCESS_TOKEN_SECRET, {
-    expiresIn: "7d",
+    expiresIn: 5 * 60,
   });
 };
 

--- a/src/services/auth/RefreshToken/clear.js
+++ b/src/services/auth/RefreshToken/clear.js
@@ -1,0 +1,1 @@
+module.exports = (res) => res.cookie("jid", "", { maxAge: 0 });

--- a/src/services/auth/RefreshToken/index.js
+++ b/src/services/auth/RefreshToken/index.js
@@ -1,9 +1,11 @@
 const create = require("./create");
 const send = require("./send");
 const verify = require("./verify");
+const clear = require("./clear");
 
 module.exports = {
   create,
   send,
   verify,
+  clear,
 };


### PR DESCRIPTION
- add logout for clearing the refresh-token cookie
- do not send a new refresh-token, while generating a new access-token using the refresh-token
- ~~decrease access-token lifetime to 5mins~~
- set access-token expiry back to 7d as mobile app team hasn't implemented refresh-token usage